### PR TITLE
[FEATURE] Add timestamps to chat messages

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -101,7 +101,7 @@ void log_message(const char *fmt, ...) {
     pthread_mutex_lock(&app_state.chat_mutex);
     
     time_t rawtime;
-    struct tm *timeinfo;
+    const struct tm *timeinfo;
     char timestamp[12];
     time(&rawtime);
     timeinfo = localtime(&rawtime);


### PR DESCRIPTION
## Description
Added Grey Color to Messages

## Related Issue
Issue #1 [FEATURE] Add timestamps to chat messages

<img width="396" height="132" alt="image" src="https://github.com/user-attachments/assets/1ba5adb0-c43f-475b-a2e9-645124cb6c6a" />

