### PR TITLE
Feat/13/file transfer confirmation

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -3,6 +3,7 @@
 
 #include <netinet/in.h>
 #include <time.h>
+#include <stdint.h>
 
 #define BROADCAST_PORT 9000
 #define BROADCAST_IP "255.255.255.255"

--- a/include/network.h
+++ b/include/network.h
@@ -13,7 +13,9 @@
 typedef enum {
     MSG_TEXT,
     MSG_FILE_METADATA,
-    MSG_FILE_CHUNK
+    MSG_FILE_CHUNK,
+    MSG_FILE_ACCEPT,
+    MSG_FILE_REJECT
 } MessageType;
 
 typedef struct {
@@ -43,5 +45,6 @@ int get_local_ip(char *ip_buffer, size_t buffer_size);
 void init_network_threads();
 void send_text_message(int peer_index, const char *msg);
 void send_file(int peer_index, const char *filepath);
+void send_file_response(int sock, int accepted);
 
 #endif

--- a/include/ui.h
+++ b/include/ui.h
@@ -21,6 +21,16 @@ typedef struct {
 
     int selected_peer_index;
     int running;
+
+    // File transfer confirmation
+    int pending_file_transfer;
+    char pending_sender[USERNAME_LEN];
+    char pending_filename[256];
+    size_t pending_filesize;
+    int pending_sock;
+    time_t pending_transfer_time;
+    pthread_mutex_t file_transfer_mutex;
+
 } AppState;
 
 extern AppState app_state;
@@ -31,5 +41,8 @@ void draw_interface();
 void log_message(const char *fmt, ...);
 void handle_input();
 void show_help();
+void show_file_prompt(const char *sender, const char *filename, size_t filesize);
+void accept_file_transfer();
+void reject_file_transfer();
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ void save_config_file(const char *username, int port) {
     printf("Configuration saved to %s\n", path);
 }
 
-void handle_config_command(int argc, char *argv[]) {
+void handle_config_command(int argc, char * const argv[]) {
     char username[USERNAME_LEN];
     int port;
 
@@ -139,7 +139,6 @@ void handle_config_command(int argc, char *argv[]) {
     save_config_file(username, port);
 }
 
-// cppcheck-suppress constParameter
 int main(int argc, char *argv[]) {
     char config_username[USERNAME_LEN];
     int config_port = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -61,8 +61,8 @@ int load_config_file(char *username, int *port) {
             char *end = val + strlen(val) - 1;
             while (end > val && isspace((unsigned char)*end)) *end-- = '\0';
 
-            strncpy(username, val, USERNAME_LEN);
-            username[USERNAME_LEN - 1] = '\0';
+            memset(username, 0, USERNAME_LEN);
+            strncpy(username, val, USERNAME_LEN - 1);
             if (username[0] != '\0') {
                 found_username = 1;
             }
@@ -114,7 +114,7 @@ void save_config_file(const char *username, int port) {
     printf("Configuration saved to %s\n", path);
 }
 
-void handle_config_command(int argc, char * const argv[]) {
+void handle_config_command(int argc, char * const * argv) {
     char username[USERNAME_LEN];
     int port;
 
@@ -150,8 +150,8 @@ int main(int argc, char *argv[]) {
 
     if (argc == 3) {
         // 1️⃣ Use command-line arguments
-        strncpy(app_state.local_username, argv[1], USERNAME_LEN);
-        app_state.local_username[USERNAME_LEN - 1] = '\0';
+        memset(app_state.local_username, 0, USERNAME_LEN);
+        strncpy(app_state.local_username, argv[1], USERNAME_LEN - 1);
 
         char *endptr;
         long val = strtol(argv[2], &endptr, 10);
@@ -164,8 +164,8 @@ int main(int argc, char *argv[]) {
 
     } else if (argc == 1 && load_config_file(config_username, &config_port)) {
         // 2️⃣ Fallback to config file when no CLI arguments are provided
-        strncpy(app_state.local_username, config_username, USERNAME_LEN);
-        app_state.local_username[USERNAME_LEN - 1] = '\0';
+        memset(app_state.local_username, 0, USERNAME_LEN);
+        strncpy(app_state.local_username, config_username, USERNAME_LEN - 1);
         app_state.local_tcp_port = config_port;
 
     } else {

--- a/src/network.c
+++ b/src/network.c
@@ -82,7 +82,8 @@ void *beacon_sender(void *arg) {
 
     BeaconPacket packet;
     while (app_state.running) {
-        strncpy(packet.username, app_state.local_username, USERNAME_LEN);
+        memset(packet.username, 0, USERNAME_LEN);
+        strncpy(packet.username, app_state.local_username, USERNAME_LEN - 1);
         packet.tcp_port = app_state.local_tcp_port;
 
         sendto(sock, &packet, sizeof(packet), 0, (struct sockaddr *)&addr, sizeof(addr));
@@ -138,7 +139,8 @@ void *beacon_receiver(void *arg) {
             }
             if (!found && app_state.peer_count < MAX_PEERS) {
                 Peer new_peer;
-                strncpy(new_peer.username, packet.username, USERNAME_LEN);
+                memset(new_peer.username, 0, USERNAME_LEN);
+                strncpy(new_peer.username, packet.username, USERNAME_LEN - 1);
                 new_peer.ip_addr = sender_addr.sin_addr;
                 new_peer.tcp_port = packet.tcp_port;
                 new_peer.last_seen = time(NULL);
@@ -323,8 +325,9 @@ void send_text_message(int peer_index, const char *msg) {
 
     if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
         MessagePacket header;
+        memset(&header, 0, sizeof(header));
         header.type = MSG_TEXT;
-        strncpy(header.sender_name, app_state.local_username, USERNAME_LEN);
+        strncpy(header.sender_name, app_state.local_username, USERNAME_LEN - 1);
         header.payload_len = strlen(msg);
         send_all(sock, &header, sizeof(header));
         send_all(sock, msg, header.payload_len);

--- a/src/network.c
+++ b/src/network.c
@@ -21,6 +21,14 @@ static ssize_t send_all(int sock, const void *buf, size_t len) {
     return total;
 }
 
+void send_file_response(int sock, int accepted) {
+    MessagePacket response;
+    response.type = accepted ? MSG_FILE_ACCEPT : MSG_FILE_REJECT;
+    strncpy(response.sender_name, app_state.local_username, USERNAME_LEN);
+    response.payload_len = 0;
+    send_all(sock, &response, sizeof(response));
+}
+
 int get_local_ip(char *ip_buffer, size_t buffer_size) {
     struct ifaddrs *ifaddr, *ifa;
     int found = 0;
@@ -167,25 +175,79 @@ void *connection_handler(void *arg) {
             if (filename) filename++;
             else filename = meta.filename;
 
-            log_message("%s is sending file: %s (%ld bytes)", header.sender_name, filename, meta.file_size);
+            // Set up pending transfer
+            pthread_mutex_lock(&app_state.file_transfer_mutex);
+            app_state.pending_file_transfer = 1;
+            strncpy(app_state.pending_sender, header.sender_name, USERNAME_LEN);
+            strncpy(app_state.pending_filename, filename, 256);
+            app_state.pending_filesize = meta.file_size;
+            app_state.pending_sock = sock;
+            app_state.pending_transfer_time = time(NULL);
+            pthread_mutex_unlock(&app_state.file_transfer_mutex);
 
-            int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-            if (fd >= 0) {
-                size_t total_received = 0;
-                char buffer[CHUNK_SIZE];
-                while (total_received < meta.file_size) {
-                    MessagePacket chunk_header;
-                    if (recv(sock, &chunk_header, sizeof(chunk_header), MSG_WAITALL) != sizeof(chunk_header)) break;
-                    if (chunk_header.type != MSG_FILE_CHUNK) break;
+            // Show prompt to user
+            show_file_prompt(header.sender_name, filename, meta.file_size);
 
-                    if ((size_t)recv(sock, buffer, chunk_header.payload_len, MSG_WAITALL) != chunk_header.payload_len) break;
-
-                    write(fd, buffer, chunk_header.payload_len);
-                    total_received += chunk_header.payload_len;
+            // Wait for user decision (max 30 seconds)
+            int decision = 0;
+            time_t start_time = time(NULL);
+            while (decision == 0 && (time(NULL) - start_time) < 30) {
+                pthread_mutex_lock(&app_state.file_transfer_mutex);
+                if (app_state.pending_file_transfer == 2) {
+                    decision = 1; // Accept
+                } else if (app_state.pending_file_transfer == -1) {
+                    decision = -1; // Reject
                 }
-                close(fd);
-                log_message("File received: %s", filename);
+                pthread_mutex_unlock(&app_state.file_transfer_mutex);
+
+                if (decision == 0) {
+                    usleep(100000); // 100ms
+                }
             }
+
+            // Timeout = reject
+            if (decision == 0) {
+                decision = -1;
+                log_message("File transfer from %s timed out (rejected)", header.sender_name);
+            }
+
+            // Send response
+            send_file_response(sock, decision == 1);
+
+            // Clear pending transfer
+            pthread_mutex_lock(&app_state.file_transfer_mutex);
+            app_state.pending_file_transfer = 0;
+            app_state.pending_sock = -1;
+            pthread_mutex_unlock(&app_state.file_transfer_mutex);
+
+            // If accepted, receive the file
+            if (decision == 1) {
+                int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+                if (fd >= 0) {
+                    size_t total_received = 0;
+                    char buffer[CHUNK_SIZE];
+                    while (total_received < meta.file_size) {
+                        MessagePacket chunk_header;
+                        if (recv(sock, &chunk_header, sizeof(chunk_header), MSG_WAITALL) != sizeof(chunk_header)) break;
+                        if (chunk_header.type != MSG_FILE_CHUNK) break;
+
+                        if ((size_t)recv(sock, buffer, chunk_header.payload_len, MSG_WAITALL) != chunk_header.payload_len) break;
+
+                        write(fd, buffer, chunk_header.payload_len);
+                        total_received += chunk_header.payload_len;
+                    }
+                    close(fd);
+                    log_message("File received: %s", filename);
+                } else {
+                    log_message("Failed to open file for writing: %s", filename);
+                }
+            } else {
+                log_message("File transfer rejected: %s", filename);
+            }
+        } else if (header.type == MSG_FILE_ACCEPT) {
+            log_message("File transfer accepted by %s", header.sender_name);
+        } else if (header.type == MSG_FILE_REJECT) {
+            log_message("File transfer rejected by %s", header.sender_name);
         }
     }
 
@@ -306,16 +368,33 @@ void send_file(int peer_index, const char *filepath) {
         meta.file_size = fsize;
         send_all(sock, &meta, sizeof(meta));
 
-        char buffer[CHUNK_SIZE];
-        ssize_t bytes_read;
-        while ((bytes_read = read(fd, buffer, sizeof(buffer))) > 0) {
-            header.type = MSG_FILE_CHUNK;
-            strncpy(header.sender_name, app_state.local_username, USERNAME_LEN);
-            header.payload_len = bytes_read;
-            if (send_all(sock, &header, sizeof(header)) <= 0) break;
-            if (send_all(sock, buffer, bytes_read) <= 0) break;
+        log_message("Waiting for %s to accept file transfer...", peer.username);
+
+        // Wait for accept/reject response
+        MessagePacket response;
+        if (recv(sock, &response, sizeof(response), MSG_WAITALL) == sizeof(response)) {
+            if (response.type == MSG_FILE_ACCEPT) {
+                log_message("File transfer accepted by %s", peer.username);
+
+                // Send file chunks
+                char buffer[CHUNK_SIZE];
+                ssize_t bytes_read;
+                while ((bytes_read = read(fd, buffer, sizeof(buffer))) > 0) {
+                    header.type = MSG_FILE_CHUNK;
+                    strncpy(header.sender_name, app_state.local_username, USERNAME_LEN);
+                    header.payload_len = bytes_read;
+                    if (send_all(sock, &header, sizeof(header)) <= 0) break;
+                    if (send_all(sock, buffer, bytes_read) <= 0) break;
+                }
+                log_message("Sent file %s to %s", filepath, peer.username);
+            } else if (response.type == MSG_FILE_REJECT) {
+                log_message("File transfer rejected by %s", peer.username);
+            } else {
+                log_message("Invalid response from %s", peer.username);
+            }
+        } else {
+            log_message("No response from %s", peer.username);
         }
-        log_message("Sent file %s to %s", filepath, peer.username);
     } else {
         log_message("Failed to connect to %s", peer.username);
     }

--- a/src/ui.c
+++ b/src/ui.c
@@ -186,12 +186,22 @@ void show_help() {
     wattron(app_state.win_chat, COLOR_PAIR(3));
     wprintw(app_state.win_chat, "  /file <path>");
     wattroff(app_state.win_chat, COLOR_PAIR(3));
-    wprintw(app_state.win_chat, "  - Send a file to the selected peer\n");
+    wprintw(app_state.win_chat, "\t \t- Send a file to the selected peer\n");
+
+    wattron(app_state.win_chat, COLOR_PAIR(3));
+    wprintw(app_state.win_chat, "  /accept");
+    wattroff(app_state.win_chat, COLOR_PAIR(3));
+    wprintw(app_state.win_chat, "\t \t- Accept an incoming file transfer\n");
+
+    wattron(app_state.win_chat, COLOR_PAIR(3));
+    wprintw(app_state.win_chat, "  /reject");
+    wattroff(app_state.win_chat, COLOR_PAIR(3));
+    wprintw(app_state.win_chat, "\t \t- Reject an incoming file transfer\n");
 
     wattron(app_state.win_chat, COLOR_PAIR(3));
     wprintw(app_state.win_chat, "  /help");
     wattroff(app_state.win_chat, COLOR_PAIR(3));
-    wprintw(app_state.win_chat, "         - Show this help message\n");
+    wprintw(app_state.win_chat, "\t \t \t- Show this help message\n");
 
     wprintw(app_state.win_chat, "\n");
 
@@ -204,12 +214,12 @@ void show_help() {
     wattron(app_state.win_chat, COLOR_PAIR(4));
     wprintw(app_state.win_chat, "  UP/DOWN");
     wattroff(app_state.win_chat, COLOR_PAIR(4));
-    wprintw(app_state.win_chat, "       - Select peer\n");
+    wprintw(app_state.win_chat, "\t \t- Select peer\n");
 
     wattron(app_state.win_chat, COLOR_PAIR(4));
     wprintw(app_state.win_chat, "  ESC");
     wattroff(app_state.win_chat, COLOR_PAIR(4));
-    wprintw(app_state.win_chat, "           - Quit\n");
+    wprintw(app_state.win_chat, "\t \t \t- Quit\n");
 
     // Add spacing after help message
     wprintw(app_state.win_chat, "\n");


### PR DESCRIPTION
## Description
### Implements the **file transfer confirmation** feature requested in #13.
Recipients can now accept or reject incoming file transfers instead of automatically receiving them.
Includes a 30-second timeout that defaults to rejection.

## Key Changes
* Added `MSG_FILE_ACCEPT` and `MSG_FILE_REJECT` message types to protocol
* Implemented `send_file_response()` function for accept/reject signaling
* Added file transfer confirmation state to `AppState`:
  * Pending transfer details (sender, filename, size)
  * File transfer mutex for thread safety
  * Decision tracking (pending/accepted/rejected)
* Created `show_file_prompt()` to display incoming transfer details:
  * Sender name, filename, and file size
  * `/accept` and `/reject` command options
  * Visual timeout warning (30 seconds)
* Added `/accept` and `/reject` commands to handle user decisions
* Updated `/help` to show new commands
* Updated `send_file()` to wait for receiver response:
  * Shows "Waiting for [peer] to accept..." message
  * Only sends file chunks after receiving accept
  * Notifies sender if transfer is rejected

## Test Output
https://github.com/user-attachments/assets/eabdec61-1d61-4dc7-aba8-1d26c3bbd1e7

