### PR TITLE
Add basic Tab completion for /file command

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -369,10 +369,10 @@ void handle_input() {
                         file_prefix = last_slash + 1;
                     }
 
-                    size_t file_prefix_len = strlen(file_prefix);
                     DIR *dir = opendir(dir_path);
                     if (dir) {
-                        struct dirent *entry;
+                        size_t file_prefix_len = strlen(file_prefix);
+                        const struct dirent *entry;
                         char match_name[256] = {0};
                         int match_count = 0;
 


### PR DESCRIPTION
This PR introduces a minimal Tab-based inline autocomplete for the `/file` command.

### Current behavior
- When typing `/file <prefix>`, pressing Tab will autocomplete the filename if **exactly one** file in the current directory matches the prefix.
- If there are zero or multiple matches, no completion is applied.

The implementation is intentionally small and self-contained to keep the change easy to review.  
If this approach looks good, I’d be happy to continue iterating on it (for example, extracting the logic into a helper function, adding directory support, or implementing common-prefix completion).
